### PR TITLE
Add prefix into allkeys

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,14 @@ class ServerlessExportOutputs {
       this.config && this.config.output && this.config.output.format
         ? this.config.output.format
         : defaultFormat;
+    const targetPrefix =
+      this.config && this.config.output && this.config.output.prefix
+        ? this.config.output.prefix
+        : defaultFormat;
     let formattedOutputs = null;
+    
+    outputs[key] = outputs[key].map(i => targetPrefix + i)
+    console.log("Output${outputs[key]});
 
     switch (targetFormat.toLowerCase()) {
       case 'toml':

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class ServerlessExportOutputs {
     let formattedOutputs = null;
     
     outputs[key] = outputs[key].map(i => targetPrefix + i)
-    console.log("Output${outputs[key]});
+    console.log(`Output${outputs[key]}`);
 
     switch (targetFormat.toLowerCase()) {
       case 'toml':

--- a/index.js
+++ b/index.js
@@ -89,7 +89,8 @@ class ServerlessExportOutputs {
         key = Object.keys(entry)[0];
         obj = entry;
       }
-      targetOutputs[targetPrefix+key] = obj[key];
+      console.log(`key: ${key}`)
+      targetOutputs[key] = obj[key];
     });
 
     return targetOutputs;

--- a/index.js
+++ b/index.js
@@ -120,8 +120,10 @@ class ServerlessExportOutputs {
         : defaultFormat;
     let formattedOutputs = null;
     
-    outputs[key] = outputs[key].map(i => targetPrefix + i)
-    console.log(`Output${outputs[key]}`);
+    console.log(`Outputs: ${outputs}`);
+    console.log(`Prefix: ${targetPrefix}`);
+//     outputs[key] = outputs[key].map(i => targetPrefix + i)
+//     console.log(`Output: ${outputs[key]}`);
 
     switch (targetFormat.toLowerCase()) {
       case 'toml':

--- a/index.js
+++ b/index.js
@@ -76,12 +76,16 @@ class ServerlessExportOutputs {
       ? this.config
       : this.config.include || [];
     const targetOutputs = {};
-
+    
+    const targetPrefix =
+      this.config && this.config.output && this.config.output.prefix
+        ? this.config.output.prefix
+        : defaultFormat;
     targetOutputKeys.forEach(entry => {
       let key = entry;
       let obj = outputs;
       if (isObject(entry)) {
-        key = Object.keys(entry)[0];
+        key = targetPrefix + Object.keys(entry)[0];
         obj = entry;
       }
       targetOutputs[key] = obj[key];
@@ -114,16 +118,7 @@ class ServerlessExportOutputs {
       this.config && this.config.output && this.config.output.format
         ? this.config.output.format
         : defaultFormat;
-    const targetPrefix =
-      this.config && this.config.output && this.config.output.prefix
-        ? this.config.output.prefix
-        : defaultFormat;
     let formattedOutputs = null;
-    
-    console.log(`Outputs: ${JSON.stringify(outputs)}`);
-    console.log(`Prefix: ${targetPrefix}`);
-//     outputs[key] = outputs[key].map(i => targetPrefix + i)
-//     console.log(`Output: ${outputs[key]}`);
 
     switch (targetFormat.toLowerCase()) {
       case 'toml':

--- a/index.js
+++ b/index.js
@@ -81,17 +81,15 @@ class ServerlessExportOutputs {
       this.config && this.config.output && this.config.output.prefix
         ? this.config.output.prefix
         : "";
-    console.log(`targetPrefix: ${targetPrefix}`);
-    console.log(`prefix: ${this.config.output.prefix}`);
     
     targetOutputKeys.forEach(entry => {
-      let key = targetPrefix + entry;
+      let key = entry;
       let obj = outputs;
       if (isObject(entry)) {
-        key = targetPrefix + Object.keys(entry)[0];
+        key = Object.keys(entry)[0];
         obj = entry;
       }
-      targetOutputs[key] = obj[key];
+      targetOutputs[targetPrefix+key] = obj[key];
     });
 
     return targetOutputs;

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class ServerlessExportOutputs {
         : defaultFormat;
     let formattedOutputs = null;
     
-    console.log(`Outputs: ${outputs}`);
+    console.log(`Outputs: ${JSON.stringify(outputs)}`);
     console.log(`Prefix: ${targetPrefix}`);
 //     outputs[key] = outputs[key].map(i => targetPrefix + i)
 //     console.log(`Output: ${outputs[key]}`);

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ class ServerlessExportOutputs {
     console.log(`prefix: ${this.config.output.prefix}`);
     
     targetOutputKeys.forEach(entry => {
-      let key = entry;
+      let key = targetPrefix + entry;
       let obj = outputs;
       if (isObject(entry)) {
         key = targetPrefix + Object.keys(entry)[0];

--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ class ServerlessExportOutputs {
     const targetPrefix =
       this.config && this.config.output && this.config.output.prefix
         ? this.config.output.prefix
-        : defaultFormat;
+        : "";
+    console.log(`targetPrefix: ${targetPrefix}`);
+    console.log(`prefix: ${this.config.output.prefix}`);
+    
     targetOutputKeys.forEach(entry => {
       let key = entry;
       let obj = outputs;

--- a/index.js
+++ b/index.js
@@ -89,8 +89,7 @@ class ServerlessExportOutputs {
         key = Object.keys(entry)[0];
         obj = entry;
       }
-      console.log(`key: ${key}`)
-      targetOutputs[key] = obj[key];
+      targetOutputs[targetPrefix+key] = obj[key];
     });
 
     return targetOutputs;


### PR DESCRIPTION
The feature to put PREFIX into all variables.

```yaml
output:
    prefix: VUE_APP
```

Here is the toml version of `.env` output:
```toml
VUE_APP_BucketName = "sample-bucket"
```

## Usecases

### Load `.env` on a vue-cli project

According to [this article](https://cli.vuejs.org/guide/mode-and-env.html#environment-variables), most of vue app need `APP_VUE_` prefix of the `.env` files.